### PR TITLE
Load plugins from the command line

### DIFF
--- a/bin/commands/help.js
+++ b/bin/commands/help.js
@@ -9,6 +9,7 @@ var flags = [
   '--version      show hydro version',
   '--no-colors    disable colors',
   '--timeout      timeout for async tests',
+  '--plugins      specify plugin(s) to use',
   '--setup        specify setup file(s) to use',
   '--stack-limit  stack trace limit',
 ];

--- a/lib/hydro.js
+++ b/lib/hydro.js
@@ -229,7 +229,7 @@ Hydro.prototype.run = function(fn) {
  */
 
 Hydro.prototype.loadPlugins = function() {
-  util.forEach(this.get('plugins'), function(plugin) {
+  util.forEach(util.toArray(this.get('plugins')), function(plugin) {
     plugin = loa(plugin);
     plugin(this, util);
     this.plugins.push(plugin);

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -2,6 +2,7 @@ var join = require('path').join;
 var nixt = require('nixt');
 var bin = join(__dirname, '..', '..', 'bin');
 
+
 t('--version', function(done) {
   cli()
   .stdout(require('../../package.json').version)
@@ -18,6 +19,27 @@ t('--help', function(done) {
   .end(done);
 });
 
+t('--plugins', function(done) {
+  cli()
+  .stdout(/fixturePlugin is set to 1/)
+  .run('--plugins ' + fixturePath('plugin.js') + ' ' + fixturePath('ensure-plugin-loaded.js'))
+  .code(0)
+  .end(done);
+});
+
+t('two --plugins', function(done) {
+  cli()
+  .stdout(/fixturePlugin is set to 2/)
+  .run('--plugins ' + fixturePath('plugin.js') + ' --plugins ' + fixturePath('plugin.js') + ' ' + fixturePath('ensure-plugin-loaded.js'))
+  .code(0)
+  .end(done);
+});
+
+
 function cli() {
   return nixt({ newlines: false }).cwd(bin).base('./hydro ');
+}
+
+function fixturePath(fileName) {
+  return join(__dirname, '..', 'support', 'fixtures', fileName);
 }

--- a/test/support/fixtures/ensure-plugin-loaded.js
+++ b/test/support/fixtures/ensure-plugin-loaded.js
@@ -1,0 +1,1 @@
+console.log("fixturePlugin is set to " + fixturePlugin);

--- a/test/support/fixtures/plugin.js
+++ b/test/support/fixtures/plugin.js
@@ -1,3 +1,5 @@
+var loadCount = 0;
 module.exports = function(hydro) {
+  hydro.set('globals', 'fixturePlugin', ++loadCount);
   module.exports.called = true;
 };


### PR DESCRIPTION
This was actually working fine... unless you just wanted one plugin, in which case `argvee` supplied a String for `this.get('plugins')` instead of an Array, and everything went to hell in a handbasket.
